### PR TITLE
Add option to specify currency symbol.  Updated documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,11 @@ struct ContentView: View {
     @State private var value = 0.0
 
     var body: some View {
+        //Minimal configuration
         CurrencyTextField("Amount", value: self.$value)
+        
+        //All configurations
+        CurrencyTextField("Amount", value: self.$value, alwaysShowFractions: false, numberOfDecimalPlaces: 2, currencySymbol: "US$")
             .font(.largeTitle)
             .multilineTextAlignment(TextAlignment.center)
     }


### PR DESCRIPTION
This option si backwards compatible and sticks to default currency system symbol. If set, the currency is forced to the currency symbol specified in the initializer.