### PR TITLE
Fix dark mode color switching

### DIFF
--- a/Sources/SwiftUIKit/views/CurrencyTextField.swift
+++ b/Sources/SwiftUIKit/views/CurrencyTextField.swift
@@ -148,14 +148,7 @@ public struct CurrencyTextField: UIViewRepresentable {
         }
         
         // color
-        switch context.environment.colorScheme {
-        case .dark:
-            textField.textColor = .white
-        case .light:
-            textField.textColor = .black
-        @unknown default:
-            break
-        }
+        textField.textColor = UIColor.label
         if let fgc = self.foregroundColor {
             textField.textColor = fgc
         }


### PR DESCRIPTION
The existing text color implementation did not use the automatic color changing built into UIColor, but rather set the color at runtime. Closes #27